### PR TITLE
Licence: change packages licence to MIT

### DIFF
--- a/avg-gas-fee-calculator/package.json
+++ b/avg-gas-fee-calculator/package.json
@@ -7,12 +7,13 @@
     "start": "./index.js"
   },
   "keywords": [
-    "rsk",
+    "RSK",
+    "Rootstock",
     "web3.js",
     "javascript"
   ],
-  "author": "Aleks Shenshin, Brendan Graetz",
-  "license": "GPL-3.0",
+  "author": "Aleksandr Shenshin, Brendan Graetz",
+  "license": "MIT",
   "type": "module",
   "dependencies": {
     "axios": "^0.26.1",

--- a/collectibles-rsk-deployment/README.md
+++ b/collectibles-rsk-deployment/README.md
@@ -1,6 +1,6 @@
 # How to deploy collectible NFTs to RSK
 
-- (Pinata)[https://app.pinata.cloud/] is an IPFS cloud gateway. Create an acount and upload the images of future NFTs. Remember the image CIDs
+- [Pinata](https://app.pinata.cloud/) is an IPFS cloud gateway. Create an acount and upload the images of future NFTs. Remember the image CIDs
 - create metadata for the NFTs. See the JSON examples in `nft-metadata` folder. Put your image CIDs to the JSON `image` property
 - upload JSON metadata files to Pinata and store their CIDs. Paste these CIDs into a file `project.config.js` to `newCIDsToMint` property
 - switch to node.js 12 and install Hardhat and the project

--- a/collectibles-rsk-deployment/hardhat.config.js
+++ b/collectibles-rsk-deployment/hardhat.config.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 require('@nomiclabs/hardhat-waffle');
 const mnemonic = require('./utils').readMnemonic();
 const { deployContracts, writeDeployments, mintNfts } = require('./utils');

--- a/collectibles-rsk-deployment/package.json
+++ b/collectibles-rsk-deployment/package.json
@@ -1,5 +1,7 @@
 {
   "name": "meow-nft",
+  "author": "Aleksandr Shenshin, Brendan Graetz",
+  "license": "MIT",
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.5",
     "@nomiclabs/hardhat-waffle": "^2.0.3",

--- a/create2/package.json
+++ b/create2/package.json
@@ -6,9 +6,13 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "keywords": [
+    "RSK",
+    "Rootstock",
+    "Solidity"
+  ],
+  "author": "Aleksandr Shenshin, Brendan Graetz",
+  "license": "MIT",
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^1.0.2",
     "hardhat": "^2.10.1"

--- a/erc1363-function-selector/package.json
+++ b/erc1363-function-selector/package.json
@@ -6,9 +6,14 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "keywords": [
+    "RSK",
+    "Rootstock",
+    "Solidity",
+    "ERC1363"
+  ],
+  "author": "Aleksandr Shenshin, Brendan Graetz",
+  "license": "MIT",
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^1.0.2",
     "erc-payable-token": "^4.7.4",

--- a/estimate-deployment-price/package.json
+++ b/estimate-deployment-price/package.json
@@ -1,5 +1,7 @@
 {
   "name": "hardhat-project",
+  "author": "Aleksandr Shenshin, Brendan Graetz",
+  "license": "MIT",
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.5",
     "@nomiclabs/hardhat-waffle": "^2.0.3",

--- a/ethers-event-listening/block-hardhat/package.json
+++ b/ethers-event-listening/block-hardhat/package.json
@@ -1,5 +1,7 @@
 {
   "name": "hardhat-project",
+  "author": "Aleksandr Shenshin, Brendan Graetz",
+  "license": "MIT",
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.5",
     "@nomiclabs/hardhat-waffle": "^2.0.3",

--- a/hardhat-demo-ethers-waffle/package.json
+++ b/hardhat-demo-ethers-waffle/package.json
@@ -9,9 +9,13 @@
     "hardhat": "npx hardhat test --network hardhat",
     "test": "npm run regtest"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "author": "Aleksandr Shenshin, Brendan Graetz",
+  "license": "MIT",
+  "keywords": [
+    "RSK",
+    "Rootstock",
+    "Hardhat"
+  ],
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.5",
     "@nomiclabs/hardhat-waffle": "^2.0.3",

--- a/hardhat-demo-web3-truffle/package.json
+++ b/hardhat-demo-web3-truffle/package.json
@@ -6,9 +6,13 @@
   "scripts": {
     "test": "npx hardhat test --network rskregtest"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "keywords": [
+    "RSK",
+    "Rootstock",
+    "Hardhat"
+  ],
+  "author": "Aleksandr Shenshin, Brendan Graetz",
+  "license": "MIT",
   "devDependencies": {
     "@nomiclabs/hardhat-truffle5": "^2.0.5",
     "@nomiclabs/hardhat-web3": "^2.0.0",

--- a/hardhat-deploy/package.json
+++ b/hardhat-deploy/package.json
@@ -6,9 +6,13 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "keywords": [
+    "RSK",
+    "Rootstock",
+    "Hardhat"
+  ],
+  "author": "Aleksandr Shenshin, Brendan Graetz",
+  "license": "MIT",
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^1.0.2",
     "@nomiclabs/hardhat-ethers": "npm:hardhat-deploy-ethers@^0.3.0-beta.13",

--- a/hardhat-rsk-deployment/package.json
+++ b/hardhat-rsk-deployment/package.json
@@ -1,5 +1,7 @@
 {
   "name": "hardhat-rsk-deployment",
+  "author": "Aleksandr Shenshin, Brendan Graetz",
+  "license": "MIT",
   "scripts": {
     "compile": "npx hardhat compile",
     "test": "npx hardhat test",

--- a/hardhat-tasks/cache/solidity-files-cache.json
+++ b/hardhat-tasks/cache/solidity-files-cache.json
@@ -1,0 +1,4 @@
+{
+  "_format": "hh-sol-cache-2",
+  "files": {}
+}

--- a/hardhat-typescript/package.json
+++ b/hardhat-typescript/package.json
@@ -1,5 +1,7 @@
 {
   "name": "hardhat-project",
+  "author": "Aleksandr Shenshin, Brendan Graetz",
+  "license": "MIT",
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.5",
     "@nomiclabs/hardhat-waffle": "^2.0.3",

--- a/multicall-0xsequence/package.json
+++ b/multicall-0xsequence/package.json
@@ -6,9 +6,15 @@
   "scripts": {
     "build": "npx browserify index.js -o bundle.js"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "keywords": [
+    "RSK",
+    "Rootstock",
+    "Solidity",
+    "multicall",
+    "DApp"
+  ],
+  "author": "Aleksandr Shenshin, Brendan Graetz",
+  "license": "MIT",
   "dependencies": {
     "@0xsequence/multicall": "^0.42.9",
     "ethers": "^5.7.2"

--- a/multicall-3/package.json
+++ b/multicall-3/package.json
@@ -6,9 +6,15 @@
   "scripts": {
     "build": "npx browserify index.js -o bundle.js"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "keywords": [
+    "RSK",
+    "Rootstock",
+    "Solidity",
+    "multicall",
+    "DApp"
+  ],
+  "author": "Aleksandr Shenshin, Brendan Graetz",
+  "license": "MIT",
   "dependencies": {
     "ethereum-multicall": "^2.15.0",
     "ethers": "^5.7.2"

--- a/nft-deploy-mint/package.json
+++ b/nft-deploy-mint/package.json
@@ -1,5 +1,14 @@
 {
   "name": "meow-nft",
+  "keywords": [
+    "RSK",
+    "Rootstock",
+    "Solidity",
+    "NFT",
+    "ERC721"
+  ],
+  "author": "Aleksandr Shenshin, Brendan Graetz",
+  "license": "MIT",
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.5",
     "@nomiclabs/hardhat-waffle": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,11 @@
     "url": "git+https://github.com/rsksmart/demo-code-snippets.git"
   },
   "keywords": [
-    "rsk"
+    "RSK",
+    "Rootstock"
   ],
-  "author": "Brendan Graetz, Aleks Shenshin",
-  "license": "GPL-3.0",
+  "author": "Brendan Graetz, Aleksandr Shenshin",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/rsksmart/demo-code-snippets/issues"
   },

--- a/rsk-deployers-ma/package.json
+++ b/rsk-deployers-ma/package.json
@@ -6,9 +6,13 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "keywords": ["RSK"],
-  "author": "Aleks Shenshin",
-  "license": "GPL-3.0",
+  "keywords": [
+    "RSK",
+    "Rootstock",
+    "SQL"
+  ],
+  "author": "Aleksandr Shenshin, Brendan Graetz",
+  "license": "MIT",
   "dependencies": {
     "dotenv": "^16.0.1",
     "pg": "^8.8.0",

--- a/rsk-deployments-ma/package.json
+++ b/rsk-deployments-ma/package.json
@@ -6,9 +6,13 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "keywords": ["RSK"],
-  "author": "Aleks Shenshin",
-  "license": "GPL-3.0",
+  "keywords": [
+    "RSK",
+    "Rootstock",
+    "SQL"
+  ],
+  "author": "Aleksandr Shenshin, Brendan Graetz",
+  "license": "MIT",
   "dependencies": {
     "dotenv": "^16.0.1",
     "pg": "^8.8.0",

--- a/rsk-stackoverflow-stats/package.json
+++ b/rsk-stackoverflow-stats/package.json
@@ -7,9 +7,13 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "keywords": [
+    "RSK",
+    "Rootstock",
+    "StackOverflow"
+  ],
+  "author": "Aleksandr Shenshin, Brendan Graetz",
+  "license": "MIT",
   "dependencies": {
     "axios": "^0.27.2",
     "colors": "^1.4.0"

--- a/rsk-testnet-deployment-stats/package.json
+++ b/rsk-testnet-deployment-stats/package.json
@@ -5,10 +5,12 @@
   "description": "RSK testnet deployments statistics",
   "main": "index.js",
   "keywords": [
-    "rsk"
+    "RSK",
+    "Rootstock",
+    "SQL"
   ],
-  "author": "Brendan Graetz, Aleks Shenshin",
-  "license": "GPL-3.0",
+  "author": "Aleksandr Shenshin, Brendan Graetz",
+  "license": "MIT",
   "dependencies": {
     "colors": "^1.4.0",
     "dotenv": "^16.0.1",

--- a/tx-origin-msg-sender/package.json
+++ b/tx-origin-msg-sender/package.json
@@ -6,9 +6,13 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "keywords": [
+    "RSK",
+    "Rootstock",
+    "Solidity"
+  ],
+  "author": "Aleksandr Shenshin, Brendan Graetz",
+  "license": "MIT",
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^1.0.2",
     "hardhat": "^2.10.2"

--- a/usedapp/package.json
+++ b/usedapp/package.json
@@ -1,7 +1,15 @@
 {
   "name": "usedapp",
   "version": "0.1.0",
-  "private": true,
+  "keywords": [
+    "RSK",
+    "Rootstock",
+    "react",
+    "useDApp",
+    "DApp"
+  ],
+  "author": "Aleksandr Shenshin, Brendan Graetz",
+  "license": "MIT",
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",

--- a/web3-react-show-balance/package.json
+++ b/web3-react-show-balance/package.json
@@ -1,7 +1,15 @@
 {
   "name": "web3-react-show-balance",
   "version": "0.1.0",
-  "private": true,
+  "keywords": [
+    "RSK",
+    "Rootstock",
+    "react",
+    "web3.js",
+    "DApp"
+  ],
+  "author": "Aleksandr Shenshin, Brendan Graetz",
+  "license": "MIT",
   "dependencies": {
     "react": "^17.0.2",
     "react-dom": "^17.0.2",


### PR DESCRIPTION
## What

In all repos `package.json` files:
- Change licenses to MIT
- Add authors
- Add keywords

## Why

Brendan Graetz:

> btw for licence, IOV uses GPL-3.0 or MIT for everything that is open source.
> for the demo code snippets, I suggest that MIT is better (although both are OK)
> so perhaps in a separate PR, change the licences for each directory to MIT.