### PR TITLE
feat: Switch to Rootstock in Metamask

### DIFF
--- a/switch-network-to-rsk/.eslintrc.json
+++ b/switch-network-to-rsk/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+  "env": {
+    "browser": true
+  },
+  "rules": {
+    "no-use-before-define": "off"
+  }
+}

--- a/switch-network-to-rsk/README.md
+++ b/switch-network-to-rsk/README.md
@@ -1,0 +1,12 @@
+# Switch to Rootstock in Metamask
+
+This demo repo shows how to programmatically switch the network to Rootstock in Metamask.
+
+A web page `index.html` allows to:
+- select Rootstock network (Testnet ot Mainnet)
+- add the selected network to Metamask
+- switch to the newly added network
+
+Rootstock networks settings are in `networks.js`
+
+Run `index.html` in Live Server

--- a/switch-network-to-rsk/index.html
+++ b/switch-network-to-rsk/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>How to switch network to Rootstock programmatically in Metamask</title>
+  <link rel="stylesheet" href="./style.css">
+</head>
+<body>
+  <h1>How to switch network to Rootstock programmatically in Metamask</h1>
+  <div id="connect-prompt">
+    <h2>Connect your wallet to Rootstock</h2>
+    <button id="connect-testnet">Connect to Testnet</button>
+    <button id="connect-mainnet">Connect to Mainnet</button>
+  </div>
+  <div id="connected" class="hidden">
+    <h2>Connected Metamask to <span id="chain-name"></span></h2>
+    <p>Wallet address: <span id="wallet-address"></span></p>
+  </div>
+  <div class="error" id="error"></div>
+  <script type="module" src="./index.js"></script>
+</body>
+</html>

--- a/switch-network-to-rsk/index.js
+++ b/switch-network-to-rsk/index.js
@@ -1,0 +1,67 @@
+import { rskTestnet, rskMainnet } from './networks.js';
+
+async function connectProviderTo(network) {
+  try {
+    // make sure Metamask is installed
+    if (!window.ethereum) throw new Error('Please install Metamask!');
+    // connect wallet
+    const [address] = await window.ethereum.request({
+      method: 'eth_requestAccounts',
+    });
+    await switchToNetwork(network);
+    showPage(network.chainName, address);
+  } catch (error) {
+    showError(error.message);
+  }
+}
+
+// see details in Metamask documentation:
+// https://docs.metamask.io/guide/rpc-api.html#wallet-addethereumchain
+async function switchToNetwork(network) {
+  try {
+    // trying to switch to a network already added to Metamask
+    await window.ethereum.request({
+      method: 'wallet_switchEthereumChain',
+      params: [{ chainId: network.chainId }],
+    });
+    // catching specific error 4902
+  } catch (error) {
+    // this error code indicates that the chain has not been added to Metamask
+    if (error.code === 4902) {
+      // trying to add new chain to Metamask
+      await window.ethereum.request({
+        method: 'wallet_addEthereumChain',
+        params: [network],
+      });
+    } else {
+      // rethrow all other errors
+      throw error;
+    }
+  }
+  // make sure we switched
+  const chainId = await window.ethereum.request({ method: 'eth_chainId' });
+  if (chainId !== network.chainId)
+    throw new Error(`Could not connect to ${network.chainName}`);
+}
+
+async function showPage(chainName, address) {
+  document.getElementById('connect-prompt').classList.add('hidden');
+  document.getElementById('connected').classList.remove('hidden');
+  document.getElementById('chain-name').innerHTML = chainName;
+  document.getElementById('wallet-address').innerHTML = address;
+}
+
+function showError(message = '') {
+  document.getElementById('error').innerHTML = message;
+  if (!message) return;
+  // hide error message in 3 seconds
+  setTimeout(() => showError(''), 3000);
+}
+
+// add click event listeners to the Connect buttons
+document
+  .getElementById('connect-testnet')
+  .addEventListener('click', () => connectProviderTo(rskTestnet));
+document
+  .getElementById('connect-mainnet')
+  .addEventListener('click', () => connectProviderTo(rskMainnet));

--- a/switch-network-to-rsk/networks.js
+++ b/switch-network-to-rsk/networks.js
@@ -1,0 +1,21 @@
+export const rskTestnet = {
+  chainName: 'Rootstock Testnet',
+  chainId: '0x1f',
+  rpcUrls: ['https://public-node.testnet.rsk.co'],
+  blockExplorerUrls: ['https://explorer.testnet.rsk.co/'],
+  nativeCurrency: {
+    symbol: 'tRBTC',
+    decimals: 18,
+  },
+};
+
+export const rskMainnet = {
+  chainName: 'Rootstock Mainnet',
+  chainId: '0x1e',
+  rpcUrls: ['https://public-node.rsk.co'],
+  blockExplorerUrls: ['https://explorer.rsk.co/'],
+  nativeCurrency: {
+    symbol: 'RBTC',
+    decimals: 18,
+  },
+};

--- a/switch-network-to-rsk/style.css
+++ b/switch-network-to-rsk/style.css
@@ -1,0 +1,8 @@
+.hidden {
+  display: none;
+}
+.error {
+  margin-top: 2rem;
+  font-size: 2rem;
+  color: red;
+}


### PR DESCRIPTION
## What
This demo repo shows how to programmatically switch the network to Rootstock in Metamask.

A web page `index.html` allows to:
- select Rootstock network (Testnet ot Mainnet)
- add the selected network to Metamask
- switch to the newly added network