### PR TITLE
useDApp @ Rootstock demo repo

### DIFF
--- a/usedapp-rootstock/.gitignore
+++ b/usedapp-rootstock/.gitignore
@@ -1,0 +1,23 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/usedapp-rootstock/README.md
+++ b/usedapp-rootstock/README.md
@@ -1,0 +1,27 @@
+# Build on Rootstock with useDApp
+
+This demo repo shows how to build a DApp on Rootstock using [useDApp](https://usedapp.io/) React library
+
+## App Components
+Different React components perform various tasks:
+- `usedapp.config.js` configures useDApp to work with Rootstock networks
+- `Connect.jsx` initiates web3 provider connection
+- `SwitchNetwork.jsx` connects to either Rootstock Testnet or Rootstock Mainnet
+- `Dashboard.jsx` shows the blockchain data within the selected Rootstock network:
+  - Chain ID
+  - Chain name
+  - Account address
+  - Account RBTC balance
+  - Account RIF token balance
+- `SendRbtc.jsx` sends the specified RBTC amount to the specified address
+- `App.jsx` connects all components and implements the app logic:
+  1. when the web3 provider (Metamask) is not connected, allows user to initiate the connection
+  2. if the provider is connected to a network other than Rootstock, prompts to switch the network to either Rootstock Mainnet or Rootstock Testnet
+  3. when connected to Rootstock, displays the Dashboard and offers to send RBTC
+
+## Installation
+To launch the demo React app, run:
+```shell
+npm install
+npm start
+```

--- a/usedapp-rootstock/README.md
+++ b/usedapp-rootstock/README.md
@@ -5,15 +5,16 @@ This demo repo shows how to build a DApp on Rootstock using [useDApp](https://us
 ## App Components
 Different React components perform various tasks:
 - `usedapp.config.js` configures useDApp to work with Rootstock networks
-- `Connect.jsx` initiates web3 provider connection
-- `SwitchNetwork.jsx` connects to either Rootstock Testnet or Rootstock Mainnet
+- `index.jsx` connects useDApp context provider
+- `Connect.jsx` prompts user to initiate web3 provider connection
+- `SwitchNetwork.jsx` prompts user to connect to either Rootstock Testnet or Rootstock Mainnet
 - `Dashboard.jsx` shows the blockchain data within the selected Rootstock network:
   - Chain ID
   - Chain name
   - Account address
   - Account RBTC balance
   - Account RIF token balance
-- `SendRbtc.jsx` sends the specified RBTC amount to the specified address
+- `SendRbtc.jsx` allows to send a specified RBTC amount to a specified address
 - `App.jsx` connects all components and implements the app logic:
   1. when the web3 provider (Metamask) is not connected, allows user to initiate the connection
   2. if the provider is connected to a network other than Rootstock, prompts to switch the network to either Rootstock Mainnet or Rootstock Testnet

--- a/usedapp-rootstock/package.json
+++ b/usedapp-rootstock/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "usedapp-rootstock",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "@usedapp/core": "^1.2.3-dev.f3c2181",
+    "ethers": "^5.7.2",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1",
+    "sass": "^1.57.1"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  },
+  "eslintConfig": {
+    "extends": [
+      "react-app",
+      "react-app/jest"
+    ]
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  }
+}

--- a/usedapp-rootstock/public/index.html
+++ b/usedapp-rootstock/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Build on Rootstock with useDApp</title>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/usedapp-rootstock/src/App.jsx
+++ b/usedapp-rootstock/src/App.jsx
@@ -1,0 +1,32 @@
+import { useEthers } from '@usedapp/core';
+import PageContainer from './components/PageContainer';
+import Connect from './components/Connect';
+import SwitchNetwork from './components/SwitchNetwork';
+import Dashboard from './components/Dashboard';
+import SendRbtc from './components/SendRbtc';
+import dappConfig from './usedapp.config';
+
+function App() {
+  const { account, chainId } = useEthers();
+
+  return (
+    <PageContainer>
+      {!account ? (
+        <Connect />
+      ) : (
+        <>
+          {!dappConfig.readOnlyUrls[chainId] ? (
+            <SwitchNetwork />
+          ) : (
+            <>
+              <Dashboard />
+              <SendRbtc />
+            </>
+          )}
+        </>
+      )}
+    </PageContainer>
+  );
+}
+
+export default App;

--- a/usedapp-rootstock/src/components/Connect.jsx
+++ b/usedapp-rootstock/src/components/Connect.jsx
@@ -1,0 +1,13 @@
+import { useEthers } from '@usedapp/core';
+
+function Connect() {
+  const { activateBrowserWallet } = useEthers();
+
+  return (
+    <div>
+      <button onClick={() => activateBrowserWallet()}>Connect</button>
+    </div>
+  );
+}
+
+export default Connect;

--- a/usedapp-rootstock/src/components/Dashboard.jsx
+++ b/usedapp-rootstock/src/components/Dashboard.jsx
@@ -1,0 +1,46 @@
+import { utils } from 'ethers';
+import { useEthers, useEtherBalance, useTokenBalance } from '@usedapp/core';
+import dappConfig from '../usedapp.config';
+
+const rif = {
+  31: '0x19f64674D8a5b4e652319F5e239EFd3bc969a1FE',
+  30: '0x2acc95758f8b5f583470ba265eb685a8f45fc9d5',
+};
+
+function Dashboard() {
+  const { account, chainId } = useEthers();
+  const rbtcBalance = useEtherBalance(account);
+  const rifBalance = useTokenBalance(rif[chainId].toLowerCase(), account);
+
+  const getChainName = (id) =>
+    dappConfig.networks.find((chain) => chain.chainId === id).chainName;
+
+  return (
+    <table className="dashboard">
+      <tbody>
+        <tr>
+          <td>Chain ID</td>
+          <td>{chainId}</td>
+        </tr>
+        <tr>
+          <td>Chain name</td>
+          <td>{getChainName(chainId)}</td>
+        </tr>
+        <tr>
+          <td>Account</td>
+          <td>{account}</td>
+        </tr>
+        <tr>
+          <td>RBTC balance</td>
+          <td>{utils.formatEther(rbtcBalance ?? 0)} RBTC</td>
+        </tr>
+        <tr>
+          <td>RIF balance</td>
+          <td>{utils.formatEther(rifBalance ?? 0)} RIF</td>
+        </tr>
+      </tbody>
+    </table>
+  );
+}
+
+export default Dashboard;

--- a/usedapp-rootstock/src/components/PageContainer.jsx
+++ b/usedapp-rootstock/src/components/PageContainer.jsx
@@ -1,0 +1,13 @@
+function PageContainer({ children }) {
+  return (
+    <div className="container">
+      <h1>Build on Rootstock with useDApp</h1>
+      {children}
+      <p>
+        <strong>Created by IOV Labs DevEx team</strong>
+      </p>
+    </div>
+  );
+}
+
+export default PageContainer;

--- a/usedapp-rootstock/src/components/SendRbtc.jsx
+++ b/usedapp-rootstock/src/components/SendRbtc.jsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import { utils } from 'ethers';
+import { useSendTransaction } from '@usedapp/core';
+
+const faucetAddress = '0x88250f772101179a4ecfaa4b92a983676a3ce445';
+
+function SendRbtc() {
+  const { sendTransaction, state } = useSendTransaction();
+  const [addressTo, setAddressTo] = useState(faucetAddress);
+  const [rbtcToSend, setRbtcToSend] = useState(0.000001);
+
+  const sendRbtc = async () => {
+    const rbtcAmount = utils.parseEther(rbtcToSend.toString());
+    const address = utils.getAddress(addressTo);
+    await sendTransaction({ to: address, value: rbtcAmount });
+  };
+  return (
+    <div className="send-rbtc">
+      <label>
+        Send
+        <input
+          type="number"
+          value={rbtcToSend}
+          onChange={(e) => setRbtcToSend(e.target.value)}
+          min={0}
+          step={0.001}
+        />
+        RBTC
+      </label>
+      <label>
+        to address
+        <input
+          type="text"
+          value={addressTo}
+          onChange={(e) => setAddressTo(e.target.value)}
+        />
+      </label>
+      {state.status === 'Mining' && (
+        <p>Mining transaction {state.transaction.hash}</p>
+      )}
+      <button type="button" onClick={sendRbtc}>
+        Send transaction
+      </button>
+    </div>
+  );
+}
+
+export default SendRbtc;

--- a/usedapp-rootstock/src/components/SwitchNetwork.jsx
+++ b/usedapp-rootstock/src/components/SwitchNetwork.jsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import { useEthers, RootstockMainnet, RootstockTestnet } from '@usedapp/core';
+
+function SwitchNetwork() {
+  const [network, setNetwork] = useState(RootstockTestnet.chainId);
+  const { switchNetwork } = useEthers();
+
+  const selectNetwork = (e) => setNetwork(Number(e.target.value));
+
+  return (
+    <div className="switch-networks">
+      <h2>Select one of the supported networks:</h2>
+      <label>
+        <input
+          type="radio"
+          name="network"
+          value={RootstockMainnet.chainId}
+          checked={network === RootstockMainnet.chainId}
+          onChange={selectNetwork}
+        />
+        {RootstockMainnet.chainName}
+      </label>
+      <label>
+        <input
+          type="radio"
+          name="network"
+          value={RootstockTestnet.chainId}
+          checked={network === RootstockTestnet.chainId}
+          onChange={selectNetwork}
+        />
+        {RootstockTestnet.chainName}
+      </label>
+      <button onClick={() => switchNetwork(network)}>Switch</button>
+    </div>
+  );
+}
+
+export default SwitchNetwork;

--- a/usedapp-rootstock/src/index.jsx
+++ b/usedapp-rootstock/src/index.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { DAppProvider } from '@usedapp/core';
+import dappConfig from './usedapp.config';
+import './index.scss';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <DAppProvider config={dappConfig}>
+      <App />
+    </DAppProvider>
+  </React.StrictMode>,
+);

--- a/usedapp-rootstock/src/index.scss
+++ b/usedapp-rootstock/src/index.scss
@@ -1,0 +1,58 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  padding: 1rem;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+button {
+  cursor: pointer;
+}
+
+@mixin flex-container($gap: 1rem) {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: $gap;
+}
+
+.container {
+  @include flex-container;
+}
+
+.switch-networks {
+  @include flex-container($gap: 0.5rem);
+  input[type=radio] {
+    margin-right: 0.5rem;
+  }
+}
+
+.dashboard {
+  td:first-child {
+    padding-right: 1rem;
+  }
+}
+
+.send-rbtc {
+  @include flex-container($gap: 0.2rem);
+  input {
+    margin: 0 0.5rem;
+    &[type=text] {
+      width: 20rem;
+    }
+  }
+  button {
+    padding: 0 1rem;
+  }
+  p {
+    color: green;
+  }
+}

--- a/usedapp-rootstock/src/usedapp.config.js
+++ b/usedapp-rootstock/src/usedapp.config.js
@@ -1,0 +1,13 @@
+import { RootstockMainnet, RootstockTestnet } from '@usedapp/core';
+
+/** @type import('@usedapp/core').Config */
+const dappConfig = {
+  networks: [RootstockMainnet, RootstockTestnet],
+  readOnlyChainId: RootstockMainnet.chainId,
+  readOnlyUrls: {
+    [RootstockMainnet.chainId]: RootstockMainnet.rpcUrl,
+    [RootstockTestnet.chainId]: RootstockTestnet.rpcUrl,
+  },
+};
+
+export default dappConfig;


### PR DESCRIPTION
## What
This demo repo shows how to build a DApp on Rootstock using [useDApp](https://usedapp.io/) React library
See `README.md` for details
## Why
Unlike [the previous useDApp demo repo](https://github.com/rsksmart/demo-code-snippets/tree/master/usedapp), this one uses the Rootstock network configuration files that were integrated into useDApp library code base within [the PR](https://github.com/TrueFiEng/useDApp/pull/1040).